### PR TITLE
Fix default baseURL and set default proxyTable to match backend.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -44,7 +44,15 @@ module.exports = {
     // Proxy your API if using any.
     // Also see /build/script.dev.js and search for "proxy api requests"
     // https://github.com/chimurai/http-proxy-middleware
-    proxyTable: {}
+    proxyTable: {
+      '/api': {
+        target: 'http://localhost:8000/api',
+        changeOrigin: true,
+        pathRewrite: {
+          '^/api': ''
+        }
+      }
+    }
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ if (__THEME === 'mat') {
 
 Vue.use(Quasar) // Install Quasar Framework
 
-axios.defaults.baseURL = 'http://localhost/api/v1'
+axios.defaults.baseURL = 'http://localhost:8080/api/v1'
 // Check if user is logged in or not + refresh token
 auth.checkAuth(this)
 


### PR DESCRIPTION
This makes some minor changes so that the project works out of the box with the quasar-starter-backend project using the proxyTable and also fixing the incorrect default baseURL.